### PR TITLE
0.9.1 Disabling configuration client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
-## 0.9.0 Initial Release
+## 0.9.1 Disabling configuration client
+
+This release restores the ContainerSSH 0.3 functionality where passing an empty `url` in the configuration would disable fetching configuration from the config server.
+
+># 0.9.0 Initial Release
 
 This is the initial port from ContainerSSH 0.3. It is able to load ContainerSSH 0.3 configuration files, but deprecates the `listen` option in the root configuration and instead moves it to `ssh` → `listen`.

--- a/client_factory.go
+++ b/client_factory.go
@@ -10,9 +10,13 @@ func NewClient(
 	config ClientConfig,
 	logger log.Logger,
 ) (Client, error) {
-	httpClient, err := http.NewClient(config.ClientConfiguration, logger)
-	if err != nil {
-		return nil, err
+	var httpClient http.Client
+	var err error
+	if config.ClientConfiguration.Url != "" {
+		httpClient, err = http.NewClient(config.ClientConfiguration, logger)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &client{
 		httpClient: httpClient,

--- a/client_impl.go
+++ b/client_impl.go
@@ -21,6 +21,9 @@ func (c *client) Get(
 	remoteAddr net.TCPAddr,
 	connectionID string,
 ) (AppConfig, error) {
+	if c.httpClient == nil {
+		return AppConfig{}, nil
+	}
 	request := ConfigRequest{
 		Username:     username,
 		RemoteAddr:   remoteAddr.IP.String(),
@@ -29,7 +32,7 @@ func (c *client) Get(
 	}
 	response := ConfigResponseBody{}
 	var lastError error = nil
-	loop:
+loop:
 	for {
 		statusCode, err := c.httpClient.Post("", &request, &response)
 		lastError = err
@@ -45,7 +48,7 @@ func (c *client) Get(
 		select {
 		case <-ctx.Done():
 			break loop
-		case <- time.After(10 * time.Second):
+		case <-time.After(10 * time.Second):
 		}
 	}
 	if lastError != nil {


### PR DESCRIPTION
This release restores the ContainerSSH 0.3 functionality where passing an empty `url` in the configuration would disable fetching configuration from the config server.